### PR TITLE
Add docs re: secondary guest account

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ The library is currently supported on
 
 TBD
 
+# Account Information
+
+Because of the way the Eufy Security private API works, an email/password combo cannot
+work with _both_ the Eufy Security mobile app _and_ this library. It is recommended to
+use the mobile app to create a secondary "guest" account with a separate email address
+and use it with this library.
+
 # Usage
 
 Everything starts with an:


### PR DESCRIPTION
This PR adds a suggestion about a secondary account to the documentation.

Fixes https://github.com/FuzzyMistborn/python-eufy-security/issues/6.