### PR TITLE
Add retry logic upon 401 response

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,6 +20,70 @@ from .fixtures import (
 
 
 @pytest.mark.asyncio
+async def test_401_refresh_failure(
+    aresponses, devices_list_json, event_loop, login_success_json
+):
+    """Test that multiple 401 responses in a row raises the right exception."""
+    aresponses.add(
+        "mysecurity.eufylife.com",
+        "/api/v1/passport/login",
+        "post",
+        aresponses.Response(text=json.dumps(login_success_json), status=200),
+    )
+    aresponses.add(
+        "mysecurity.eufylife.com",
+        "/api/v1/app/get_devs_list",
+        "post",
+        aresponses.Response(text=None, status=401),
+    )
+    aresponses.add(
+        "mysecurity.eufylife.com",
+        "/api/v1/passport/login",
+        "post",
+        aresponses.Response(text=None, status=401),
+    )
+
+    async with aiohttp.ClientSession(loop=event_loop) as websession:
+        with pytest.raises(InvalidCredentialsError):
+            await async_login(TEST_EMAIL, TEST_PASSWORD, websession)
+
+
+@pytest.mark.asyncio
+async def test_401_refresh_success(
+    aresponses, devices_list_json, event_loop, login_success_json
+):
+    """Test that a 401 response re-authenticates successfully."""
+    aresponses.add(
+        "mysecurity.eufylife.com",
+        "/api/v1/passport/login",
+        "post",
+        aresponses.Response(text=json.dumps(login_success_json), status=200),
+    )
+    aresponses.add(
+        "mysecurity.eufylife.com",
+        "/api/v1/app/get_devs_list",
+        "post",
+        aresponses.Response(text=json.dumps(devices_list_json), status=401),
+    )
+    aresponses.add(
+        "mysecurity.eufylife.com",
+        "/api/v1/passport/login",
+        "post",
+        aresponses.Response(text=json.dumps(login_success_json), status=200),
+    )
+    aresponses.add(
+        "mysecurity.eufylife.com",
+        "/api/v1/app/get_devs_list",
+        "post",
+        aresponses.Response(text=json.dumps(devices_list_json), status=200),
+    )
+
+    async with aiohttp.ClientSession(loop=event_loop) as websession:
+        api = await async_login(TEST_EMAIL, TEST_PASSWORD, websession)
+        assert len(api.cameras) == 2
+
+
+@pytest.mark.asyncio
 async def test_bad_email(aresponses, event_loop, login_invalid_email_json):
     """Test authenticating with a bad email."""
     aresponses.add(
@@ -73,18 +137,40 @@ async def test_empty_response(
 
 
 @pytest.mark.asyncio
-async def test_http_error(aresponses, event_loop, login_success_json):
-    """Test the Eufy Security web API returning a non-2xx HTTP error code."""
+async def test_expired_access_token(
+    aresponses, devices_list_json, event_loop, login_success_json
+):
+    """Test that an expired access token refreshes automatically and correctly."""
     aresponses.add(
         "mysecurity.eufylife.com",
         "/api/v1/passport/login",
         "post",
-        aresponses.Response(text=None, status=500),
+        aresponses.Response(text=json.dumps(login_success_json), status=200),
+    )
+    aresponses.add(
+        "mysecurity.eufylife.com",
+        "/api/v1/app/get_devs_list",
+        "post",
+        aresponses.Response(text=json.dumps(devices_list_json), status=200),
+    )
+    aresponses.add(
+        "mysecurity.eufylife.com",
+        "/api/v1/passport/login",
+        "post",
+        aresponses.Response(text=json.dumps(login_success_json), status=200),
+    )
+    aresponses.add(
+        "mysecurity.eufylife.com",
+        "/api/v1/app/get_devs_list",
+        "post",
+        aresponses.Response(text=json.dumps(devices_list_json), status=200),
     )
 
     async with aiohttp.ClientSession(loop=event_loop) as websession:
-        with pytest.raises(RequestError):
-            await async_login(TEST_EMAIL, TEST_PASSWORD, websession)
+        api = await async_login(TEST_EMAIL, TEST_PASSWORD, websession)
+        api._token_expiration = datetime.now() - timedelta(seconds=10)
+        await api.async_update_device_info()
+        assert len(api.cameras) == 2
 
 
 @pytest.mark.asyncio
@@ -118,6 +204,21 @@ async def test_get_history(
 
 
 @pytest.mark.asyncio
+async def test_http_error(aresponses, event_loop, login_success_json):
+    """Test the Eufy Security web API returning a non-2xx HTTP error code."""
+    aresponses.add(
+        "mysecurity.eufylife.com",
+        "/api/v1/passport/login",
+        "post",
+        aresponses.Response(text=None, status=500),
+    )
+
+    async with aiohttp.ClientSession(loop=event_loop) as websession:
+        with pytest.raises(RequestError):
+            await async_login(TEST_EMAIL, TEST_PASSWORD, websession)
+
+
+@pytest.mark.asyncio
 async def test_login_success(
     aresponses, devices_list_json, event_loop, login_success_json
 ):
@@ -141,41 +242,4 @@ async def test_login_success(
         assert api._password == TEST_PASSWORD
         assert api._token is not None
         assert api._token_expiration is not None
-        assert len(api.cameras) == 2
-
-
-@pytest.mark.asyncio
-async def test_refreshing_access_token(
-    aresponses, devices_list_json, event_loop, login_success_json
-):
-    """Test that an expired access token refreshes automatically and correctly."""
-    aresponses.add(
-        "mysecurity.eufylife.com",
-        "/api/v1/passport/login",
-        "post",
-        aresponses.Response(text=json.dumps(login_success_json), status=200),
-    )
-    aresponses.add(
-        "mysecurity.eufylife.com",
-        "/api/v1/app/get_devs_list",
-        "post",
-        aresponses.Response(text=json.dumps(devices_list_json), status=200),
-    )
-    aresponses.add(
-        "mysecurity.eufylife.com",
-        "/api/v1/passport/login",
-        "post",
-        aresponses.Response(text=json.dumps(login_success_json), status=200),
-    )
-    aresponses.add(
-        "mysecurity.eufylife.com",
-        "/api/v1/app/get_devs_list",
-        "post",
-        aresponses.Response(text=json.dumps(devices_list_json), status=200),
-    )
-
-    async with aiohttp.ClientSession(loop=event_loop) as websession:
-        api = await async_login(TEST_EMAIL, TEST_PASSWORD, websession)
-        api._token_expiration = datetime.now() - timedelta(seconds=10)
-        await api.async_update_device_info()
         assert len(api.cameras) == 2


### PR DESCRIPTION
This PR adds some basic retry logic when the library encounters a `401 Unauthorized` HTTP error:

* If this is the first time a `401` is seen, the library with automatically generate a new access token and try the request again.
* If a second `401` response is received, the library will raise an `InvalidCredentialsError`.