### PR TITLE
Pin aiohttp to 3.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-aiohttp = "^3.6.2"
+aiohttp = "3.6.1"
 python = "^3.6.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
This PR pins `aiohttp` to 3.6.1 so that building the library from source in Home Assistant doesn't create a version mismatch.

Fixes https://github.com/FuzzyMistborn/python-eufy-security/issues/19.