### PR TITLE
Add more repos to pre-commit + include bandit

### DIFF
--- a/.bandit.yaml
+++ b/.bandit.yaml
@@ -1,0 +1,11 @@
+---
+# https://bandit.readthedocs.io/en/latest/config.html
+tests:
+  - B313
+  - B314
+  - B315
+  - B316
+  - B317
+  - B318
+  - B319
+  - B320

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,3 +68,17 @@ jobs:
       - uses: codecov/codecov-action@v1.0.3
         with:
           token: ${{secrets.CODECOV_TOKEN}}
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+          architecture: x64
+      - run: |
+          pip install poetry
+          poetry install
+      - run: |
+          poetry run bandit -r --configfile=.bandit.yaml eufy_security/ scripts/ tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,32 @@
 ---
 repos:
   - repo: https://github.com/python/black
-    rev: stable
+    rev: 19.10b0
     hooks:
       - id: black
+        args:
+          - --safe
+          - --quiet
         language_version: python3
+        files: ^((simplipy|scripts|tests)/.+)?[^/]+\.py$
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-docstrings==1.5.0
+          - pydocstyle==5.0.1
+        files: ^(simplipy|scripts|tests)/.+\.py$
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.6.2
+    hooks:
+      - id: bandit
+        args:
+          - --quiet
+          - --format=custom
+          - --configfile=.bandit.yaml
+        files: ^(simplipy|scripts|tests)/.+\.py$
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
+    hooks:
+      - id: isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ python = "^3.6.1"
 [tool.poetry.dev-dependencies]
 Sphinx = "^2.2.1"
 aresponses = "^1.1.1"
+bandit = "^1.6.2"
 black = "^19.10b0"
 docformatter = "^1.3"
 flake8 = "^3.7.9"


### PR DESCRIPTION
**Describe what the PR does:**

This PR does two things:

1. Adds [`flake8`](https://github.com/PyCQA/flake8), [`bandit`](https://github.com/PyCQA/bandit), and [`isort`](https://github.com/pre-commit/mirrors-isort) to `pre-commit` (to help future contributors not fail various checks that we enforce).
2. Includes [`bandit`](https://github.com/PyCQA/bandit) in CI.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)