### PR TITLE
Add enum converter to support param type modes

### DIFF
--- a/eufy_security/converters.py
+++ b/eufy_security/converters.py
@@ -1,8 +1,9 @@
 """Define converters."""
 import base64
 from datetime import datetime, timezone
+from enum import Enum
 import json
-from typing import Any, Union
+from typing import Any, Type, Union
 
 
 class StringConverter:
@@ -98,3 +99,21 @@ class DatetimeConverter:
     def dumps(value: datetime) -> str:
         """Convert datetime into a timestamp."""
         return str(int(value.replace(tzinfo=timezone.utc).timestamp()))
+
+
+class EnumConverter:
+    """Convert values to and from an enum."""
+
+    def __init__(self, enum: Type[Enum]):
+        """Initialise converter with given enum."""
+        self._enum = enum
+
+    def loads(self, value: Any) -> Enum:
+        """Return the enum for the given value."""
+        return self._enum(value)
+
+    def dumps(self, value: Enum) -> Any:
+        """Return the value for the given enum."""
+        if not isinstance(value, self._enum):
+            value = self._enum[value]
+        return value.value

--- a/eufy_security/types.py
+++ b/eufy_security/types.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 from .converters import (
     BoolConverter,
+    EnumConverter,
     JsonBase64Converter,
     JsonConverter,
     NumberConverter,
@@ -87,6 +88,36 @@ class DeviceType(Enum):
         ]
 
 
+class ScheduleMode(Enum):
+    """Define schedule modes."""
+
+    AWAY = "0"
+    HOME = "1"
+    DISARMED = "63"
+
+
+class GuardMode(Enum):
+    """Define guard modes."""
+
+    AWAY = "0"
+    HOME = "1"
+    SCHEDULE = "2"
+    CUSTOM1 = "3"
+    CUSTOM2 = "4"
+    CUSTOM3 = "5"
+    OFF = "6"
+    GEOFENCING = "47"
+    DISARMED = "63"
+
+
+class WatermarkMode(Enum):
+    """Define watermark modes."""
+
+    OFF = "0"
+    TIMESTAMP = "1"
+    TIMESTAMP_AND_LOGO = "2"
+
+
 class ParamType(Enum):
     """Define the types.
 
@@ -151,11 +182,11 @@ class ParamType(Enum):
 
     # Inferred from source
     SNOOZE_MODE = 1271, JsonBase64Converter
-    WATERMARK_MODE = 1214  # 1 - hide, 2 - show
+    WATERMARK_MODE = 1214, EnumConverter(WatermarkMode)
     DEVICE_UPGRADE_NOW = 1134
     CAMERA_UPGRADE_NOW = 1133
-    DEFAULT_SCHEDULE_MODE = 1257  # 0 - Away, 1 - Home, 63 - Disarmed
-    GUARD_MODE = 1224  # 0 - Away, 1 - Home, 63 - Disarmed, 2 - Schedule
+    DEFAULT_SCHEDULE_MODE = 1257, EnumConverter(ScheduleMode)
+    GUARD_MODE = 1224, EnumConverter(GuardMode)
 
     FLOODLIGHT_MANUAL_SWITCH = 1400
     FLOODLIGHT_MANUAL_BRIGHTNESS = 1401  # The range is 22-100
@@ -175,7 +206,7 @@ class ParamType(Enum):
     CAMERA_MOTION_ZONES = 1204, JsonBase64Converter
 
     # Set only params?
-    PUSH_MSG_MODE = 1252  # 0 to ???
+    PUSH_MSG_MODE = 1252  # 0 is human detection, 2 is all motions, others???
 
     PRIVATE_MODE = 99904, BoolConverter
     CUSTOM_RTSP_URL = 999991, StringConverter

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,6 +1,7 @@
 """Define tests for converters."""
 
 from datetime import datetime, timezone
+from enum import Enum
 
 import pytest
 
@@ -75,3 +76,18 @@ def test_datetime_dumps():
     """Test dumping data as a json-encoded string."""
     dt = datetime(2019, 8, 5, 12, 31, 39, tzinfo=timezone.utc)
     assert DatetimeConverter.dumps(dt) == "1565008299"
+
+
+def test_enum_loads():
+    """Test loading data to an enum."""
+    Color = Enum("Color", "RED GREEN BLUE")
+    converter = EnumConverter(Color)
+    assert converter.loads(1) == Color.RED
+
+
+def test_enum_dumps():
+    """Test dumping enum as a value."""
+    Color = Enum("Color", "RED GREEN BLUE")
+    converter = EnumConverter(Color)
+    assert converter.dumps(Color.RED) == 1
+    assert converter.dumps("RED") == 1


### PR DESCRIPTION
**Describe what the PR does:**
This extends the param types to support enums, such as guard and schedule modes.
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Add yourself to `AUTHORS.md`.
